### PR TITLE
[Hosts] Add Debian and Ubuntu as hosts

### DIFF
--- a/soscollector/hosts/__init__.py
+++ b/soscollector/hosts/__init__.py
@@ -41,6 +41,8 @@ class SosHost():
     container_runtime = None
     container_image = None
     sos_path_strip = None
+    sos_pkg_name = None  # package name in deb/rpm/etc
+    sos_bin_path = None  # path to sosreport binary
 
     def __init__(self, address):
         self.address = address

--- a/soscollector/hosts/debian.py
+++ b/soscollector/hosts/debian.py
@@ -1,4 +1,4 @@
-# Copyright Red Hat 2018, Jake Hunsaker <jhunsake@redhat.com>
+# Copyright Canonical 2018, Bryan Quigley <bryan.quigley@canonical.com>
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -16,38 +16,21 @@
 from soscollector.hosts import SosHost
 
 
-class RedHatHost(SosHost):
-    '''Base class for defining Red Hat family systems'''
+class DebianHost(SosHost):
+    '''Base class for defining Debian based systems'''
 
-    distribution = 'Red Hat'
-    release_file = '/etc/redhat-release'
-    releases = ['fedora', 'red hat', 'centos']
+    distribution = 'Debian'
+    releases = ['ubuntu', 'debian']
     package_manager = {
-        'name': 'rpm',
-        'query': 'rpm -q'
+        'name': 'dpkg',
+        'query': "dpkg-query -W -f='${Package}-${Version}\\\n' "
     }
-    sos_pkg_name = 'sos'
-    sos_bin_path = '/usr/sbin/sosreport'
+    sos_pkg_name = 'sosreport'
+    sos_bin_path = '/usr/bin/sosreport'
 
     def check_enabled(self, rel_string):
         for release in self.releases:
-            if release in rel_string.lower():
+            if release in rel_string:
                 return True
         return False
-
-
-class RedHatAtomicHost(RedHatHost):
-
-    containerized = True
-    container_runtime = 'docker'
-    container_image = 'registry.access.redhat.com/rhel7/support-tools'
-    sos_path_strip = '/host'
-
-    def check_enabled(self, rel_string):
-        return 'Atomic Host' in rel_string
-
-    def set_sos_prefix(self):
-        return "atomic run --replace --name=sos-collector-tmp %(image)s "
-
-    def set_cleanup_cmd(self):
-        return 'docker rm sos-collector-tmp'
+# vim:ts=4 et sw=4

--- a/soscollector/sosnode.py
+++ b/soscollector/sosnode.py
@@ -154,7 +154,7 @@ class SosNode():
     def _load_sos_info(self):
         '''Queries the node for information about the installed version of sos
         '''
-        cmd = self.host.prefix + self.host.pkg_query('sos')
+        cmd = self.host.prefix + self.host.pkg_query(self.host.sos_pkg_name)
         res = self.run_command(cmd)
         if res['status'] == 0:
             ver = res['stdout'].splitlines()[-1].split('-')[1]
@@ -275,7 +275,7 @@ class SosNode():
     def run_command(self, cmd, timeout=180, get_pty=False, need_root=False):
         '''Runs a given cmd, either via the SSH session or locally'''
         if cmd.startswith('sosreport'):
-            cmd = cmd.replace('sosreport', '/usr/sbin/sosreport')
+            cmd = cmd.replace('sosreport', self.host.sos_bin_path)
             need_root = True
         if need_root:
             get_pty = True


### PR DESCRIPTION
Currently Debian and Ubuntu share a hosts file but we can further
split them out if needed.

Needed to define both a package name and path variable
so that the differences between RH and U/D could be handled.

Signed-off-by: Bryan Quigley <bryan.quigley@canonical.com>